### PR TITLE
addresses ticket #26 accordion has a scroll feature for menu

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -190,3 +190,26 @@ h3 {
     font-size: 35px;
     font-family: Georgia, 'Times New Roman', Times, serif;
 }
+
+/* Sticky elements for Menu page */
+
+/* ?? wondering if this media query is part of the answer for adjusting accordion header sticky height after hamburger menu is toggled ?? 
+
+@media only screen and (max-width: 980px){
+ .navbar-collapse .collapse .show {
+ 
+    then adjust .accordion-header.sticky-top{ 
+        top: 250px;
+
+    }  ??
+ }
+}
+*/
+
+.navbar.sticky-top{
+    z-index: 1100;
+}
+
+.accordion-header.sticky-top {
+    top: 185px;
+} 

--- a/css/main.css
+++ b/css/main.css
@@ -209,7 +209,6 @@ h3 {
 .navbar.sticky-top{
     z-index: 1100;
 }
-
 .accordion-header.sticky-top {
-    top: 185px;
+    top: 180px;
 } 

--- a/css/main.css
+++ b/css/main.css
@@ -190,10 +190,3 @@ h3 {
     font-size: 35px;
     font-family: Georgia, 'Times New Roman', Times, serif;
 }
-
-/*accordion for menu page */
-
-.accordion-collapse ul {  
-    max-height: 250px;
-    overflow-y: scroll;
-}

--- a/css/main.css
+++ b/css/main.css
@@ -191,3 +191,9 @@ h3 {
     font-family: Georgia, 'Times New Roman', Times, serif;
 }
 
+/*accordion for menu page */
+
+.accordion-collapse ul {  
+    max-height: 250px;
+    overflow-y: scroll;
+}

--- a/menu.php
+++ b/menu.php
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-	<nav class="navbar navbar-expand-lg sticky-top-top navbar-light navbar-custom">
+	<nav class="navbar navbar-expand-lg sticky-top navbar-light navbar-custom">
 		<div class="container-fluid">
 			<div class="logo">
 				<a href="home.php" class="logo">

--- a/menu.php
+++ b/menu.php
@@ -230,8 +230,6 @@
 			</b>
 
 		</div>
-		<script>
-</script>
 		<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/js/bootstrap.bundle.min.js" integrity="sha384-b5kHyXgcpbZJO/tY9Ul7kGkf1S0CWuKcCD38l8YkeH8z8QjE0GmW1gYU5S9FOnJ0" crossorigin="anonymous"></script>
 </body>
 

--- a/menu.php
+++ b/menu.php
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-	<nav class="navbar navbar-expand-lg sticky-top navbar-light navbar-custom">
+	<nav class="navbar navbar-expand-lg sticky-top-top navbar-light navbar-custom">
 		<div class="container-fluid">
 			<div class="logo">
 				<a href="home.php" class="logo">
@@ -48,7 +48,7 @@
 
 	<div class="accordion accordion-flush" id="accordianMenu">
 		<div class="accordion-item">
-			<h2 class="accordion-header" id="coffee">
+			<h2 class="accordion-header sticky-top" id="coffee">
 				<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
 					Specialty Coffee
 				</button>
@@ -69,7 +69,7 @@
 			</div>
 		</div>
 		<div class="accordion-item">
-			<h2 class="accordion-header" id="regularCoffee">
+			<h2 class="accordion-header sticky-top" id="regularCoffee">
 				<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseEight" aria-expanded="false" aria-controls="collapseEight">
 					Regular Coffee
 				</button>
@@ -90,7 +90,7 @@
 		</div>
 
 		<div class="accordion-item">
-			<h2 class="accordion-header" id="breakfastSingles">
+			<h2 class="accordion-header sticky-top" id="breakfastSingles">
 				<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
 					Breakfast Singles
 				</button>
@@ -109,7 +109,7 @@
 			</div>
 		</div>
 		<div class="accordion-item">
-			<h2 class="accordion-header" id="breakfastCombos">
+			<h2 class="accordion-header sticky-top" id="breakfastCombos">
 				<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
 					Breakfast Combos
 				</button>
@@ -127,7 +127,7 @@
 			</div>
 		</div>
 		<div class="accordion-item">
-			<h2 class="accordion-header" id="traditionalWings">
+			<h2 class="accordion-header sticky-top" id="traditionalWings">
 				<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFour" aria-expanded="false" aria-controls="collapseFour">
 					Traditional Wings - $13.99/10p | $21.99/21p
 				</button>
@@ -150,7 +150,7 @@
 		</div>
 
 		<div class="accordion-item">
-			<h2 class="accordion-header" id="specialityWings">
+			<h2 class="accordion-header sticky-top" id="specialityWings">
 				<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFive" aria-expanded="false" aria-controls="collapseFive">
 					StarBulls Specialty Wings
 				</button>
@@ -175,7 +175,7 @@
 		</div>
 
 		<div class="accordion-item">
-			<h2 class="accordion-header" id="bullsDinner">
+			<h2 class="accordion-header sticky-top" id="bullsDinner">
 				<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSix" aria-expanded="false" aria-controls="collapseSix">
 					Bulls Dinner
 				</button>
@@ -192,7 +192,7 @@
 		</div>
 
 		<div class="accordion-item">
-			<h2 class="accordion-header" id="sides">
+			<h2 class="accordion-header sticky-top" id="sides">
 				<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSeven" aria-expanded="false" aria-controls="collapseSeven">
 					Sides
 				</button>
@@ -230,6 +230,8 @@
 			</b>
 
 		</div>
+		<script>
+</script>
 		<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/js/bootstrap.bundle.min.js" integrity="sha384-b5kHyXgcpbZJO/tY9Ul7kGkf1S0CWuKcCD38l8YkeH8z8QjE0GmW1gYU5S9FOnJ0" crossorigin="anonymous"></script>
 </body>
 


### PR DESCRIPTION
menu accordions have a scroll feature, set at 250px, works well for large and small screens, added to css on main.css line 196. 
Once open the menu section is not sticky, not sure if it is needed but can work that out as well if that is preferred. 

closes #26 
