### PR TITLE
about us image adjusted, text adjusted with bootstrap

### DIFF
--- a/about.php
+++ b/about.php
@@ -12,56 +12,60 @@
 
 <body>
 	<?php include 'navbar.php'; ?>
-	<h2 class="us">About Us</h2>
-	<div class="company">
-		<h3>Company Information</h3>
-		<p>We are the StarBulls. The mighty, mighty StarBulls. Everywhere we go, people want to know:
-			WHO WE
-			ARE! So we tell
-			them: WE ARE THE STARBULLS; THE MIGHTY, MIGHTY STARBULLS!</p>
-	</div>
-	<div class="heritage">
-		<h3>Our Heritage</h3>
-		<p>We are humbled by the success of our company thus far. The name StarBulls was created by Will, 
-			one of our founders. Fueled by a continual flow of caffeine and blue cheese, Will opened StarBulls in Febuary of 2021.
-		</p>
-		<p>How do we measure success? Simply: we started from the bottom, now we are here! Seriously,
-			look at our site! A beauty to say the least.
-		</p>
-		<p>Just a week ago, StarBulls did not exist. It has taken hours of dedication, caffeine, and chicken wings to get this 
-			company up on the server. Days of frustration, trying to figure out why the code looks different on
-			our screens. Hours of trial and error as we figured out where we went wrong. One thing the
-			founders of StarBulls knew from the beginning is: Quitters Never Win. And Winners Never Quit. At
-			StarBulls we are Winners!
-		</p>
-	</div>
-	<div class="tools">
-		<h3>Tools We Used</h3>
-		<p>Like any other company, the founders of StarBulls rely on various resources and tools to help
-			create this site. We want to share our tools and resources with the world!
-		</p>
-		<h3>They are:</h3>
-		<ol>
-			<li>Bill C.: You may have heard of him. The Man. The Myth. The Legend. If you haven't, then
-				maybe StarBulls is not for you!</li>
-			<li>Google.com: This one can have you running in circles BUT a lot of questions have been
-				answered by our friend Google.</li>
-			<li>Last but not least, the founders at StarBulls, relied on one another and other
-				classmates.
-			</li>
-		</ol>
-	</div>
-	<div id="myCarousel" class="carousel slide" data-ride="carousel">
-		<div class="carousel-inner">
-			<img src="imgs/cofee3.png" width="100%">
-			<div class="item active">
-				<div class="carousel-caption d-none d-md-block">
-					<div class="hero-text">
-						<h2>StarBulls</h2>
+	<div class="conatiner containerAbout">
+		<div id="myCarousel" class="carousel slide" data-ride="carousel">
+			<div class="carousel-inner">
+				<img src="imgs/cofee3.png" width="100%">
+				<div class="item active">
+					<div class="carousel-caption">
+						<h1 class="p-4">About Us</h1>
 					</div>
 				</div>
 			</div>
 		</div>
+		<div class="row my-5 px-3 px-5">
+			<div class="aboutInfo1 p-4">
+				<p>We are the StarBulls. The mighty, mighty StarBulls. </br> Everywhere we go, people want to know:
+					WHO WE
+					ARE! So we tell
+					them: </br><strong> WE ARE THE STARBULLS; THE MIGHTY, MIGHTY STARBULLS!</strong></p>
+			</div>
+			<div class="my-5 px-5 p-3 aboutInfo2">
+				<h3 class="fw-bold">Our Heritage</h3>
+				<p>We are humbled by the success of our company thus far. The name StarBulls was created by Will,
+					one of our founders. Fueled by a continual flow of caffeine and blue cheese, Will opened StarBulls in Febuary of 2021.
+				</p>
+				<p>How do we measure success? Simply: we started from the bottom, now we are here! Seriously,
+					look at our site! A beauty to say the least.
+				</p>
+				<p>Just a week ago, StarBulls did not exist. It has taken hours of dedication, caffeine, and chicken wings to get this
+					company up on the server. Days of frustration, trying to figure out why the code looks different on
+					our screens. Hours of trial and error as we figured out where we went wrong. One thing the
+					founders of StarBulls knew from the beginning is: Quitters Never Win. And Winners Never Quit. At
+					StarBulls we are Winners!
+				</p>
+			</div>
+			<div class="my-5">
+				<h2>Meet Our Team</h2>
+			</div>
+		</div>
+	</div>
+	<!-- <div class="tools">
+				<h3>Tools We Used</h3>
+				<p>Like any other company, the founders of StarBulls rely on various resources and tools to help
+					create this site. We want to share our tools and resources with the world!
+				</p>
+				<h3>They are:</h3>
+				<ol>
+					<li>Bill C.: You may have heard of him. The Man. The Myth. The Legend. If you haven't, then
+						maybe StarBulls is not for you!</li>
+					<li>Google.com: This one can have you running in circles BUT a lot of questions have been
+						answered by our friend Google.</li>
+					<li>Last but not least, the founders at StarBulls, relied on one another and other
+						classmates.
+					</li>
+				</ol>
+			</div> -->
 	</div>
 	<?php include 'footer.php'; ?>
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/js/bootstrap.bundle.min.js" integrity="sha384-b5kHyXgcpbZJO/tY9Ul7kGkf1S0CWuKcCD38l8YkeH8z8QjE0GmW1gYU5S9FOnJ0" crossorigin="anonymous"></script>

--- a/about.php
+++ b/about.php
@@ -50,23 +50,6 @@
 			</div>
 		</div>
 	</div>
-	<!-- <div class="tools">
-				<h3>Tools We Used</h3>
-				<p>Like any other company, the founders of StarBulls rely on various resources and tools to help
-					create this site. We want to share our tools and resources with the world!
-				</p>
-				<h3>They are:</h3>
-				<ol>
-					<li>Bill C.: You may have heard of him. The Man. The Myth. The Legend. If you haven't, then
-						maybe StarBulls is not for you!</li>
-					<li>Google.com: This one can have you running in circles BUT a lot of questions have been
-						answered by our friend Google.</li>
-					<li>Last but not least, the founders at StarBulls, relied on one another and other
-						classmates.
-					</li>
-				</ol>
-			</div> -->
-	</div>
 	<?php include 'footer.php'; ?>
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/js/bootstrap.bundle.min.js" integrity="sha384-b5kHyXgcpbZJO/tY9Ul7kGkf1S0CWuKcCD38l8YkeH8z8QjE0GmW1gYU5S9FOnJ0" crossorigin="anonymous"></script>
 </body>

--- a/about.php
+++ b/about.php
@@ -18,7 +18,7 @@
 				<img src="imgs/cofee3.png" width="100%">
 				<div class="item active">
 					<div class="carousel-caption">
-						<h1 class="p-4">About Us</h1>
+						<h1 class="p-2 hero-text">About Us</h1>
 					</div>
 				</div>
 			</div>

--- a/about.php
+++ b/about.php
@@ -12,7 +12,7 @@
 
 <body>
 	<?php include 'navbar.php'; ?>
-	<div class="conatiner containerAbout">
+	<div class="containerAbout">
 		<div id="myCarousel" class="carousel slide" data-ride="carousel">
 			<div class="carousel-inner">
 				<img src="imgs/cofee3.png" width="100%">

--- a/css/main.css
+++ b/css/main.css
@@ -11,7 +11,7 @@ body {
 }
 
 .carousel-inner {
-	height: 400px;
+	max-height: 400px;
 }
 
 h1 {
@@ -251,12 +251,27 @@ input {
 	width: 100%;
 }
 
-.company, .heritage, .tools {
+.tools {
 	font-family: Verdana, Geneva, Tahoma, sans-serif;
 	border-radius: 6px;
 	text-align: center;
 	padding: 4%;
 }
+
+.containerAbout {
+	background-color: lightgray;
+}
+.aboutInfo1 {
+	background-color: rgba(255, 255, 255, .4);
+	border-radius: 20px;
+	text-align: center;
+}
+.aboutInfo2 {
+	background-color:  rgba(122, 242, 132, 0.461);
+	border-radius: 20px;
+	text-align: center;
+}
+
 
 .navbar.sticky-top {
 	z-index: 1100;


### PR DESCRIPTION
-moved carousel image to the top of the screen 
-implemented bootstrap layout to about us page
-About us text and Heritage modified to mirror review blurbs CSS design 
-commented out code that no longer fits direction of page but kept it in case @eiman-kased wants to use them for card portion of page, but I can delete as well if we want to scrap it. 

updates #71