### PR TITLE
fixed row margins on home

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -129,6 +129,7 @@ dt {
 
 .row.row-index {
     display: flex;
+	margin: auto;
     background-color: lightgray;
 }
 


### PR DESCRIPTION
Inserted margin-auto for row-index CSS class. This removed horizontal scroll bar for the home page. 

Closes #95 